### PR TITLE
Added tags for storage blocks and ores

### DIFF
--- a/common/src/main/resources/data/c/tags/block/ores/adamantite.json
+++ b/common/src/main/resources/data/c/tags/block/ores/adamantite.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:adamantite_ore"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/ores/cobalt.json
+++ b/common/src/main/resources/data/c/tags/block/ores/cobalt.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:cobalt_ore"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/ores/infernal.json
+++ b/common/src/main/resources/data/c/tags/block/ores/infernal.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:infernal_ore"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/ores/lead.json
+++ b/common/src/main/resources/data/c/tags/block/ores/lead.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:lead_ore"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/ores/mythril.json
+++ b/common/src/main/resources/data/c/tags/block/ores/mythril.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:mythril_ore"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/ores/orichalcum.json
+++ b/common/src/main/resources/data/c/tags/block/ores/orichalcum.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:orichalcum_ore"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/ores/palladium.json
+++ b/common/src/main/resources/data/c/tags/block/ores/palladium.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:palladium_ore"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/ores/platinum.json
+++ b/common/src/main/resources/data/c/tags/block/ores/platinum.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:platinum_ore"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/ores/silver.json
+++ b/common/src/main/resources/data/c/tags/block/ores/silver.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:silver_ore"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/ores/tin.json
+++ b/common/src/main/resources/data/c/tags/block/ores/tin.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:tin_ore"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/ores/titanium.json
+++ b/common/src/main/resources/data/c/tags/block/ores/titanium.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:titanium_ore"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/ores/tungsten.json
+++ b/common/src/main/resources/data/c/tags/block/ores/tungsten.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:tungsten_ore"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/adamantite.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/adamantite.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:adamantite_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/cobalt.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/cobalt.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:cobalt_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/infernal.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/infernal.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:infernal_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/lead.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/lead.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:lead_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/mythril.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/mythril.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:mythril_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/obsidian.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/obsidian.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:obsidian_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/orichalcum.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/orichalcum.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:orichalcum_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/palladium.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/palladium.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:palladium_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/platinum.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/platinum.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:platinum_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/raw_adamantite.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/raw_adamantite.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:raw_adamantite_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/raw_cobalt.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/raw_cobalt.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:raw_cobalt_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/raw_infernal.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/raw_infernal.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:raw_infernal_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/raw_lead.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/raw_lead.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:raw_lead_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/raw_mythril.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/raw_mythril.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:raw_mythril_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/raw_orichalcum.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/raw_orichalcum.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:orichalcum_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/raw_palladium.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/raw_palladium.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:raw_palladium_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/raw_platinum.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/raw_platinum.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:raw_platinum_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/raw_silver.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/raw_silver.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:raw_silver_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/raw_tin.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/raw_tin.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:raw_tin_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/raw_titanium.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/raw_titanium.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:raw_titanium_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/raw_tungsten.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/raw_tungsten.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:raw_tungsten_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/silver.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/silver.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:silver_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/tin.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/tin.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:tin_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/titanium.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/titanium.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:titanium_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/tungsten.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/tungsten.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:tungsten_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/ores.json
+++ b/common/src/main/resources/data/c/tags/item/ores.json
@@ -1,0 +1,17 @@
+{
+    "replace": false,
+    "values": [
+        "many_more_ores_and_crafts:tungsten_ore",
+        "many_more_ores_and_crafts:titanium_ore",
+        "many_more_ores_and_crafts:tin_ore",
+        "many_more_ores_and_crafts:silver_ore",
+        "many_more_ores_and_crafts:platinum_ore",
+        "many_more_ores_and_crafts:palladium_ore",
+        "many_more_ores_and_crafts:orichalcum_ore",
+        "many_more_ores_and_crafts:mythril_ore",
+        "many_more_ores_and_crafts:lead_ore",
+        "many_more_ores_and_crafts:infernal_ore",
+        "many_more_ores_and_crafts:cobalt_ore",
+        "many_more_ores_and_crafts:adamantite_ore"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/ores/adamantite.json
+++ b/common/src/main/resources/data/c/tags/item/ores/adamantite.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:adamantite_ore"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/ores/cobalt.json
+++ b/common/src/main/resources/data/c/tags/item/ores/cobalt.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:cobalt_ore"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/ores/infernal.json
+++ b/common/src/main/resources/data/c/tags/item/ores/infernal.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:infernal_ore"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/ores/lead.json
+++ b/common/src/main/resources/data/c/tags/item/ores/lead.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:lead_ore"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/ores/mythril.json
+++ b/common/src/main/resources/data/c/tags/item/ores/mythril.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:mythril_ore"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/ores/orichalcum.json
+++ b/common/src/main/resources/data/c/tags/item/ores/orichalcum.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:orichalcum_ore"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/ores/palladium.json
+++ b/common/src/main/resources/data/c/tags/item/ores/palladium.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:palladium_ore"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/ores/platinum.json
+++ b/common/src/main/resources/data/c/tags/item/ores/platinum.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:platinum_ore"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/ores/silver.json
+++ b/common/src/main/resources/data/c/tags/item/ores/silver.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:silver_ore"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/ores/tin.json
+++ b/common/src/main/resources/data/c/tags/item/ores/tin.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:tin_ore"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/ores/titanium.json
+++ b/common/src/main/resources/data/c/tags/item/ores/titanium.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:titanium_ore"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/ores/tungsten.json
+++ b/common/src/main/resources/data/c/tags/item/ores/tungsten.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:tungsten_ore"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/storage_blocks.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks.json
@@ -1,0 +1,30 @@
+{
+  "replace": false,
+  "values": [
+    "many_more_ores_and_crafts:raw_tungsten_block",
+    "many_more_ores_and_crafts:raw_titanium_block",
+    "many_more_ores_and_crafts:raw_tin_block",
+    "many_more_ores_and_crafts:raw_silver_block",
+    "many_more_ores_and_crafts:raw_platinum_block",
+    "many_more_ores_and_crafts:raw_palladium_block",
+    "many_more_ores_and_crafts:raw_orichalcum_block",
+    "many_more_ores_and_crafts:raw_mythril_block",
+    "many_more_ores_and_crafts:raw_lead_block",
+    "many_more_ores_and_crafts:raw_infernal_block",
+    "many_more_ores_and_crafts:raw_cobalt_block",
+    "many_more_ores_and_crafts:raw_adamantite_block",
+    "many_more_ores_and_crafts:tungsten_block",
+    "many_more_ores_and_crafts:titanium_block",
+    "many_more_ores_and_crafts:tin_block",
+    "many_more_ores_and_crafts:silver_block",
+    "many_more_ores_and_crafts:platinum_block",
+    "many_more_ores_and_crafts:palladium_block",
+    "many_more_ores_and_crafts:orichalcum_block",
+    "many_more_ores_and_crafts:obsidian_block",
+    "many_more_ores_and_crafts:mythril_block",
+    "many_more_ores_and_crafts:lead_block",
+    "many_more_ores_and_crafts:infernal_block",
+    "many_more_ores_and_crafts:cobalt_block",
+    "many_more_ores_and_crafts:adamantite_block"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/adamantite.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/adamantite.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:adamantite_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/cobalt.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/cobalt.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:cobalt_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/infernal.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/infernal.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:infernal_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/lead.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/lead.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:lead_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/mythril.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/mythril.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:mythril_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/obsidian.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/obsidian.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:obsidian_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/orichalcum.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/orichalcum.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:orichalcum_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/palladium.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/palladium.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:palladium_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/platinum.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/platinum.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:platinum_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/raw_adamantite.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/raw_adamantite.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:raw_adamantite_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/raw_cobalt.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/raw_cobalt.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:raw_cobalt_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/raw_infernal.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/raw_infernal.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:raw_infernal_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/raw_lead.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/raw_lead.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:raw_lead_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/raw_mythril.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/raw_mythril.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:raw_mythril_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/raw_orichalcum.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/raw_orichalcum.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:orichalcum_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/raw_palladium.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/raw_palladium.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:raw_palladium_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/raw_platinum.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/raw_platinum.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:raw_platinum_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/raw_silver.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/raw_silver.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:raw_silver_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/raw_tin.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/raw_tin.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:raw_tin_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/raw_titanium.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/raw_titanium.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:raw_titanium_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/raw_tungsten.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/raw_tungsten.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:raw_tungsten_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/silver.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/silver.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:silver_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/tin.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/tin.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:tin_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/titanium.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/titanium.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:titanium_block"
+    ]
+  }

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/tungsten.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/tungsten.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "many_more_ores_and_crafts:tungsten_block"
+    ]
+  }


### PR DESCRIPTION
Added #c:storage_blocks, #c:storage_blocks/{material}, #c:ores, and #c:ores/{material} to all the relevant blocks for completeness.

The tags are both item and block tags.