### PR TITLE
Fix for raw_infernal_block_recipe.json 1.21.1

### DIFF
--- a/common/src/main/resources/data/many_more_ores_and_crafts/recipe/raw_infernal_block_recipe.json
+++ b/common/src/main/resources/data/many_more_ores_and_crafts/recipe/raw_infernal_block_recipe.json
@@ -7,8 +7,9 @@
     "aaa"
   ],
   "key": {
-    "a": "#c:raw_materials/infernal",
-
+    "a": {
+      "tag": "c:raw_materials/infernal"
+    }
   },
   "result": {
     "id": "many_more_ores_and_crafts:raw_infernal_block",


### PR DESCRIPTION
Recipe was not formatted correctly for 1.21.1 caused errors in log and couldn't be crafted.